### PR TITLE
Run tests against python 3.6 stable, 3.7-dev; drop 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
+  - "3.7-dev"
   - "pypy"
 
 install:


### PR DESCRIPTION
Python 3.7 is available as alpha: https://www.python.org/dev/peps/pep-0537/#release-schedule

Python 3.3 reached its EOL: https://www.python.org/dev/peps/pep-0398/#x-end-of-life